### PR TITLE
Fix dataset cleaning and evaluation pipeline

### DIFF
--- a/prediction_model/config/config.py
+++ b/prediction_model/config/config.py
@@ -45,3 +45,8 @@ TRANSFER_LEARNING_CONFIG = {
     "pooling": "avg",
     "trainable_layers": 2,
 }
+
+# Configuraciones para la evaluación del modelo
+EVALUATION_CONFIG = {
+    "test_data_path": os.path.join(BASE_DIR, "datasets", "test"),
+}

--- a/prediction_model/datasets/data_cleaning.py
+++ b/prediction_model/datasets/data_cleaning.py
@@ -1,5 +1,19 @@
 import os
-from shutil import copyfile
+from shutil import copyfile, copytree
+from prediction_model.config.config import DATA_CLEANING_CONFIG
+
+def clean_dataset():
+    """Simple cleaning step that copies raw data to a processed folder."""
+    src = DATA_CLEANING_CONFIG["dataset_path"]
+    dst = DATA_CLEANING_CONFIG["output_folder_path"]
+    if not os.path.exists(src):
+        raise FileNotFoundError(f"Dataset path '{src}' does not exist")
+    if os.path.exists(dst):
+        # Allow running multiple times by merging contents
+        copytree(src, dst, dirs_exist_ok=True)
+    else:
+        copytree(src, dst)
+    print(f"Dataset cleaned and copied to {dst}")
 
 def download_dataset_from_drive(dataset_path, destination_path):
     """

--- a/prediction_model/training_pipeline.py
+++ b/prediction_model/training_pipeline.py
@@ -1,7 +1,7 @@
 from prediction_model.datasets.data_loading import download_files_from_folder
 from prediction_model.datasets.data_cleaning import clean_dataset
 from prediction_model.models.train import train_model
-from prediction_model.evaluation.evaluate_model import evaluate_model
+from prediction_model.evaluation.evaluate_model import evaluate_model, load_model
 from prediction_model.config.config import DATA_LOADING_CONFIG, DATA_CLEANING_CONFIG, TRAINING_CONFIG, EVALUATION_CONFIG
 
 def run_training_pipeline():
@@ -19,7 +19,8 @@ def run_training_pipeline():
 
     # Paso 4: Evaluar el modelo
     print("Evaluando el modelo...")
-    evaluate_model(TRAINING_CONFIG["model_save_path"], EVALUATION_CONFIG["test_data_path"])
+    model = load_model(TRAINING_CONFIG["model_save_path"])
+    evaluate_model(model, EVALUATION_CONFIG["test_data_path"])
 
 if __name__ == "__main__":
     run_training_pipeline()


### PR DESCRIPTION
## Summary
- implement `clean_dataset` function used in training pipeline
- add evaluation configuration path
- fix evaluation step to load the model before calling `evaluate_model`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6852c31bdc6c8328ae511650d8019c5f