### PR TITLE
Add evaluation config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ python -m prediction_model.training_pipeline
 
 ## Evaluating a Saved Model
 
-To evaluate a model stored at the path specified in `config.py`:
+To evaluate a model stored at the path specified in `config.py` using the test
+dataset defined in `EVALUATION_CONFIG`:
 
 ```bash
 python -m prediction_model.evaluation.evaluate_model

--- a/prediction_model/evaluation/evaluate_model.py
+++ b/prediction_model/evaluation/evaluate_model.py
@@ -2,7 +2,7 @@ import torch
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 from prediction_model.models.model_definitions import SimpleCNN
-from prediction_model.config.config import TRAINING_CONFIG
+from prediction_model.config.config import TRAINING_CONFIG, EVALUATION_CONFIG
 
 def load_model(model_path):
     model = SimpleCNN()
@@ -33,4 +33,7 @@ def evaluate_model(model, test_data_path):
 
 if __name__ == "__main__":
     model = load_model(TRAINING_CONFIG["model_save_path"])
-    evaluate_model(model, TRAINING_CONFIG["dataset_path"])  # Ajusta la ruta según necesidad
+    evaluate_model(
+        model,
+        EVALUATION_CONFIG["test_data_path"],
+    )

--- a/prediction_model/training_pipeline.py
+++ b/prediction_model/training_pipeline.py
@@ -17,7 +17,7 @@ def run_training_pipeline():
     print("Iniciando el entrenamiento del modelo...")
     train_model()
 
-    # Paso 4: Evaluar el modelo
+    # Paso 4: Evaluar el modelo con los datos de prueba
     print("Evaluando el modelo...")
     model = load_model(TRAINING_CONFIG["model_save_path"])
     evaluate_model(model, EVALUATION_CONFIG["test_data_path"])


### PR DESCRIPTION
## Summary
- import `EVALUATION_CONFIG` in evaluation script and use it when run as a module
- note test dataset path in training pipeline comment
- clarify README model evaluation instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca1cea248328aa7ee4b7783747a0