### PR TITLE
Fix setup directory instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ file.
 
 ## Setup
 
+Clone this repository and change into its directory:
+
+```bash
+git clone <repo-url>
+cd ComputerVisionStructureFlowersAI
+```
+
 Create a virtual environment and install the requirements:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify repository setup steps with correct directory name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prediction_model.data_loading')*

------
https://chatgpt.com/codex/tasks/task_e_6852ca1f3d508328a23bd5d4803b629a